### PR TITLE
chore: makes command make run reliable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,9 @@ services:
     ports:
       - 9090:9090
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
+
     volumes:
       - ./config.json:/app/config.json
   mysql:
@@ -22,4 +24,7 @@ services:
       - MYSQL_USER=user
       - MYSQL_PASSWORD=password
       - MYSQL_ROOT_PASSWORD=root
-
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
make run may fail in some cases where mysql startup time takes a little longer time than usual.
depends_on directive guarantees only that mysql container will be started first and web will start second and sometimes when web is trying to connect to mysql, mysql is still not ready for connections.
So health-check will first wait for mysql up and ready for connections and only then web container will launched.

btw, thanks for the great example!