### PR TITLE
chore(Dockerfile): gcc and dep are not used now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 FROM golang:1.12.8-alpine3.10 as builder
 
 RUN apk update && apk upgrade && \
-    apk --update add git gcc make && \
-    go get -u github.com/golang/dep/cmd/dep
+    apk --update add git make
 
 WORKDIR /app
 


### PR DESCRIPTION
gcc is not used in this project
when go supports go module, dep is not used in this project too.
