### PR TITLE
Unreachable  code removed

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,6 @@ func main() {
 	err = dbConn.Ping()
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 
 	defer func() {


### PR DESCRIPTION
`os.Exit(1)` is unreachable. This code can never be executed because of a `log.Fatal(err)`. It's doing the same thing with `Log.Fatal(err)`.