### PR TITLE
Fix Typo: Update Variable Name for Server Address in main.go

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -85,5 +85,5 @@ func main() {
 	if address == "" {
 		address = defaultAddress
 	}
-	log.Fatal(e.Start(os.Getenv("SERVER_ADDRESS"))) //nolint
+	log.Fatal(e.Start(address)) //nolint
 }

--- a/app/main.go
+++ b/app/main.go
@@ -81,9 +81,9 @@ func main() {
 	rest.NewArticleHandler(e, svc)
 
 	// Start Server
-	addres := os.Getenv("SERVER_ADDRESS")
-	if addres == "" {
-		addres = defaultAddress
+	address := os.Getenv("SERVER_ADDRESS")
+	if address == "" {
+		address = defaultAddress
 	}
 	log.Fatal(e.Start(os.Getenv("SERVER_ADDRESS"))) //nolint
 }


### PR DESCRIPTION
Minimal contribution.
- Fixed a possible typo. Updated the variable name storing the server address from environment variables in `main.go`.
- `address` variable was being declared but not used.